### PR TITLE
record dependencies in Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-Gemfile*
+Gemfile.lock
 .jekyll-cache/
 _site/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
- Advantage: we can locally test in the same environment as GitHub pages
- Disadvantage: a simple "jekyll serve" might not work and you may need to do https://github.com/bast/til/blob/master/documentation/jekyll-bundler.md

No pressure to accept this. I am fine also continuing without it. Only today I learned how to properly use this.