### PR TITLE
time.md: adjust to emphasize the link first.

### DIFF
--- a/time.md
+++ b/time.md
@@ -4,12 +4,15 @@ title: Convert to my time
 permalink: /time/
 ---
 
+
 We broadcast on [Twitch](https://www.twitch.tv/rshour) every Tuesday at 20:30 Central European Time /
-21:30 East European Time. You can probably find the next time by
-running the following command from your terminal:
+21:30 East European Time.  You can [check this
+link](http://www.timebie.com/std/helsinki.php?q=21.5) to see the time
+in your timezone.
+
+On Linux, you can find the next time by running the following command
+from your terminal:
 
 ```
 $ date --date='TZ="Europe/Helsinki" 21:30 next Tue'
 ```
-
-Alternatively you can check [this link](http://www.timebie.com/std/helsinki.php?q=21.5).


### PR DESCRIPTION
- the `date` command doesn't work on Mac, so I guess it's not good to
  make it our default recommended option.