### PR TITLE
Reorder social links at bottom: hackmd after videos

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,13 +17,14 @@ minima:
   social_links:
     #twitter: __radovan
     github: researchsoftwarehour
-    hackmd: "@researchsoftwarehour"
     extra:
       - url: https://twitch.tv/RSHour
         name: "twitch"
       - url: https://www.youtube.com/playlist?list=PLpLblYHCzJAB6blBBa0O2BEYadVZV3JYf
         name: "video archive"
         icon: youtube
+      - name: hackmd
+        url: "https://hackmd.io/@researchsoftwarehour"
       - url: https://twitter.com/__radovan
         name: "__radovan"
         icon: twitter

--- a/_includes/social.html
+++ b/_includes/social.html
@@ -20,7 +20,6 @@
   {%- if social.keybase -%}<li><a rel="me" href="https://keybase.io/{{ social.keybase | cgi_escape | escape }}" title="{{ social.keybase | escape }}"><svg class="svg-icon grey"><use xlink:href="{{ '/assets/minima-social-icons.svg#keybase' | relative_url }}"></use></svg></a></li>{%- endif -%}
   {%- if social.microdotblog -%}<li><a rel="me" href="https://micro.blog/{{ social.microdotblog | cgi_escape | escape }}" title="{{ social.microdotblog | escape }}"><svg class="svg-icon grey"><use xlink:href="{{ '/assets/minima-social-icons.svg#microdotblog' | relative_url }}"></use></svg></a></li>{%- endif -%}
   {%- if social.devto -%}<li><a href="https://dev.to/{{ social.devto | cgi_escape | escape }}" title="{{ social.devto | escape }}"><svg class="svg-icon grey"><use xlink:href="{{ '/assets/minima-social-icons.svg#devto' | relative_url }}"></use></svg></a></li>{%- endif -%}
-  {%- if social.hackmd -%}<li><a href="https://hackmd.io/{{ social.hackmd | escape }}" title="{{ social.hackmd | escape }}">hackmd</a></li>{%- endif -%}
   {%- for extra in social.extra -%}
   <li><a rel="me" href="{{ extra.url }}">
       {%- if extra.icon -%}<svg class="svg-icon grey"><use xlink:href="{{ '/assets/minima-social-icons.svg' | relative_url }}#{{ extra.icon }}"></use></svg>{%- endif -%}


### PR DESCRIPTION
- I had hard-coded the "hackmd" into _include/social.html, but then
  added a way to have arbitrary extra links.
- Now, hackmd was before the more important links, mainly twitch and
  the video archive.  No, de-specialize hackmd and put it between the
  video links and our personal links.