### PR TITLE
replace time converter with arewemeetingyet.com

### DIFF
--- a/time.md
+++ b/time.md
@@ -7,7 +7,7 @@ permalink: /time/
 
 We broadcast on [Twitch](https://www.twitch.tv/rshour) every Tuesday at 20:30 Central European Time /
 21:30 East European Time.  You can [check this
-link](http://www.timebie.com/std/helsinki.php?q=21.5) to see the time
+link](https://arewemeetingyet.com/Helsinki/2020-05-05/21:30/w/Research%20Software%20Hour#eyJ1cmwiOiJodHRwczovL3R3aXRjaC50di9SU0hvdXIifQ==) to see the time
 in your timezone.
 
 On Linux, you can find the next time by running the following command


### PR DESCRIPTION
- This is a MIT licensed client-side-only timezone converter, with
  recurring meeting support.  Seems better than whatever site we had
  before, although the other site provided info on many major cities
  simultaneously.
- Thanks to JupyterHub people for using it, thus letting me discover
  it.