### PR TITLE
Add /youtube and /twitch redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
-gem "jekyll-remote-theme"
+gem 'jekyll-redirect-from'
+gem 'jekyll-remote-theme'

--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,7 @@ minima:
 markdown: kramdown
 plugins:
   - jekyll-feed
+  - jekyll-redirect-from
   - jekyll-remote-theme
 # We can switch back to regular theme once >2.5.1 is released
 #theme: minima

--- a/twitch.md
+++ b/twitch.md
@@ -1,0 +1,7 @@
+---
+# This page just HTML redirects to the youtube playlist
+layout: page
+title: Twitch
+permalink: /twitch/
+redirect_to: https://twitch.tv/RSHour
+---

--- a/youtube.md
+++ b/youtube.md
@@ -1,0 +1,8 @@
+---
+# This page just HTML redirects to the youtube playlist
+layout: page
+title: Youtube
+permalink: /youtube/
+redirect_to: https://youtube.com/playlist?list=PLpLblYHCzJAB6blBBa0O2BEYadVZV3JYf
+---
+


### PR DESCRIPTION
- This is of questionable usefulness, but might be good to have a
  stable URL to link to sometimes?  Can be closed without using, but
  I've at least thought of some times that having a stable URL would
  be useful.
  - unfortunately the prefix "https://researchsoftwarehour.github.io"
    is rather long itself, making this not very useful for copyable
    URLs.
- It's a HTML redirect, not HTTP level, so not really "the right way"
  but the best we can do with gh-pages.