### PR TITLE
.github/workflows/build: change gh-actions to ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     # we use mac because zola is not distributed in ubuntu (?)
     # and I did not want to cargo build zola as part of the workflow
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     env:
       TARGET_BRANCH: gh-pages
     steps:


### PR DESCRIPTION
- gh-actions docs claim that homebrew is installed on ubuntu, too.
- Review:
  - does it build?
  - is it faster?